### PR TITLE
Add support for .env files in settings.py

### DIFF
--- a/simple_inventory/settings.py
+++ b/simple_inventory/settings.py
@@ -15,6 +15,7 @@ import os
 from pathlib import Path
 
 import environ
+
 # Build paths inside the project like this: BASE_DIR / 'subdir'.
 BASE_DIR = Path(__file__).resolve().parent.parent
 

--- a/simple_inventory/settings.py
+++ b/simple_inventory/settings.py
@@ -10,22 +10,34 @@ For the full list of settings and their values, see
 https://docs.djangoproject.com/en/4.1/ref/settings/
 """
 
+import io
+import os
 from pathlib import Path
 
+import environ
 # Build paths inside the project like this: BASE_DIR / 'subdir'.
 BASE_DIR = Path(__file__).resolve().parent.parent
 
+env = environ.Env(DEBUG=(bool, False))
+env_file = os.path.join(BASE_DIR, ".env")
+
+if os.path.isfile(env_file):
+    # use local env file
+    print("Getting env vars from local file...")
+    env.read_env(env_file)
+else:
+    raise Exception("No local .env detected!")
 
 # Quick-start development settings - unsuitable for production
 # See https://docs.djangoproject.com/en/4.1/howto/deployment/checklist/
 
 # SECURITY WARNING: keep the secret key used in production secret!
-SECRET_KEY = "django-insecure-7@*3hr5(65q!bjk%&kr&$k@w-w1!1b1qflushom(go6+_+zqd+"
+SECRET_KEY = env("SECRET_KEY")
 
 # SECURITY WARNING: don't run with debug turned on in production!
-DEBUG = True
+DEBUG = env("DEBUG")
 
-ALLOWED_HOSTS = []
+ALLOWED_HOSTS = ["*"]
 
 
 # Application definition
@@ -76,8 +88,12 @@ WSGI_APPLICATION = "simple_inventory.wsgi.application"
 
 DATABASES = {
     "default": {
-        "ENGINE": "django.db.backends.sqlite3",
-        "NAME": BASE_DIR / "db.sqlite3",
+        "ENGINE": env("SQL_ENGINE", default="django.db.backends.sqlite3"),
+        "NAME": env("SQL_DATABASE", default=str(BASE_DIR / "db.sqlite3")),
+        "USER": env("SQL_USER", default="user"),
+        "PASSWORD": env("SQL_PASSWORD", default="password"),
+        "HOST": env("SQL_HOST", default="localhost"),
+        "PORT": env("SQL_PORT", default="5432"),
     }
 }
 


### PR DESCRIPTION
This PR adds support for getting environment variables from a .env file that needs to be present locally. This variables are going to be used by django settings for things like secret key, log level and database configurations.

IMPORTANT NOTE: This is a breaking change! In order to run the development server with `python manage.py runserver` you will need to create a .env variable in the project root folder. There is an example file already called .env.test. you can create an empty .env file and copy the contents of .env.test to the new ,env file and that should work.