### PR TITLE
Add item details view and template

### DIFF
--- a/inventory/static/js/items.js
+++ b/inventory/static/js/items.js
@@ -38,6 +38,7 @@ const listItems = async () => {
                     <td>${item.description}</td>
                     <td>${item.location_id}</td>
                     <td>${item.item_status_id}</td>
+                    <td><a href="/inventory/items/${item.id}">Details</a></td>
                 </tr>
             `;
         });

--- a/inventory/templates/inventory/base.html
+++ b/inventory/templates/inventory/base.html
@@ -11,37 +11,37 @@
   <body>
     <nav class="navbar navbar-expand-lg bg-body-secondary scrolling-navbar fixed-top">
       <div class="container-fluid">
-        <span class="navbar-brand mb-0 h1" href="http://127.0.0.1:8000/inventory/">Inventory</span>
+        <span class="navbar-brand mb-0 h1" href="{% url 'index' %}">Inventory</span>
         <button class="navbar-toggler" type="button" data-bs-toggle="collapse" data-bs-target="#navbarSupportedContent" aria-controls="navbarSupportedContent" aria-expanded="false" aria-label="Toggle navigation">
           <span class="navbar-toggler-icon"></span>
         </button>
         <div class="collapse navbar-collapse" id="navbarSupportedContent">
           <ul class="navbar-nav me-auto mb-2 mb-lg-0">
             <li class="nav-item">
-              <a class="nav-link active" aria-current="page" href="http://127.0.0.1:8000/inventory/">Dashboard</a>
+              <a class="nav-link active" aria-current="page" href="{% url 'index' %}">Dashboard</a>
             </li>
             <li class="nav-item dropdown">
               <a class="nav-link dropdown-toggle" href="#" role="button" data-bs-toggle="dropdown" aria-expanded="false">
                 Operations
               </a>
               <ul class="dropdown-menu">
-                <li><a class="dropdown-item" href=http://127.0.0.1:8000/inventory/items/>Items</a></li>
-                <li><a class="dropdown-item" href=http://127.0.0.1:8000/inventory/>Customers</a></li>
-                <li><a class="dropdown-item" href=http://127.0.0.1:8000/inventory/>Locations</a></li>
+                <li><a class="dropdown-item" href="{% url 'items' %}">Items</a></li>
+                <li><a class="dropdown-item" href="{% url 'index' %}">Customers</a></li>
+                <li><a class="dropdown-item" href="{% url 'index' %}">Locations</a></li>
               </ul>
             </li>
             <li class="nav-item dropdown">
-              <a class="nav-link dropdown-toggle" href=http://127.0.0.1:8000/inventory/ role="button" data-bs-toggle="dropdown" aria-expanded="false">
+              <a class="nav-link dropdown-toggle" href="{% url 'index' %}" role="button" data-bs-toggle="dropdown" aria-expanded="false">
                 Reports
               </a>
               <ul class="dropdown-menu">
-                <li><a class="dropdown-item" href=http://127.0.0.1:8000/inventory/>Brand</a></li>
-                <li><a class="dropdown-item" href=http://127.0.0.1:8000/inventory/>Category</a></li>
-                <li><a class="dropdown-item" href=http://127.0.0.1:8000/inventory/>Model</a></li>
+                <li><a class="dropdown-item" href="{% url 'index' %}">Brand</a></li>
+                <li><a class="dropdown-item" href="{% url 'index' %}">Category</a></li>
+                <li><a class="dropdown-item" href="{% url 'index' %}">Model</a></li>
               </ul>
             </li>
             <li class="nav-item">
-              <a class="nav-link" href=http://127.0.0.1:8000/inventory/>Settings</a>
+              <a class="nav-link" href="{% url 'index' %}">Settings</a>
             </li>
           </ul>
           <form class="d-flex" role="login">

--- a/inventory/templates/inventory/item_detail.html
+++ b/inventory/templates/inventory/item_detail.html
@@ -1,0 +1,63 @@
+{% extends 'inventory/base.html' %}
+
+{% load static %}
+
+{% block body_block %}
+<div class="container mt-5">
+    <table class="table">
+  <thead>
+    <tr>
+      <th scope="col" colspan="2">Item: {{ item.model }}</th>
+    </tr>
+  </thead>
+
+  <tbody>
+    <tr>
+      <th scope="row">ID</th>
+      <td>{{ item.id }}</td>
+    </tr>
+    <tr>
+      <th scope="row">Model</th>
+      <td>{{ item.model }}</td>
+    </tr>
+    <tr>
+      <th scope="row">Brand</th>
+      <td>{{ item.brand }}</td>
+    </tr>
+    <tr>
+      <th scope="row">Quantity</th>
+      <td>{{ item.quantity }}</td>
+    </tr>
+    <tr>
+      <th scope="row">Description</th>
+      <td>{{ item.description }}</td>
+    </tr>
+    <tr>
+      <th scope="row">Location</th>
+      <td>{{ item.location }}</td>
+    </tr>
+    <tr>
+      <th scope="row">Status</th>
+      <td>{{ item.item_status }}</td>
+    </tr>
+    <tr>
+      <th scope="row">Type</th>
+      <td>{{ item.type }}</td>
+    </tr>
+    <tr>
+      <th scope="row">Category</th>
+      <td>{{ item.category }}</td>
+    </tr>
+    <tr>
+      <th scope="row">Order Date</th>
+      <td>{{ item.order_date }}</td>
+    </tr>
+    <tr>
+      <th scope="row">Check Date</th>
+      <td>{{ item.check_date }}</td>
+    </tr>
+
+  </tbody>
+</table>
+</div>
+{% endblock %}

--- a/inventory/templates/inventory/item_detail.html
+++ b/inventory/templates/inventory/item_detail.html
@@ -4,60 +4,66 @@
 
 {% block body_block %}
 <div class="container mt-5">
-    <table class="table">
-  <thead>
-    <tr>
-      <th scope="col" colspan="2">Item: {{ item.model }}</th>
-    </tr>
-  </thead>
+    <div class="row">
+        <div class="col-sm">
 
-  <tbody>
-    <tr>
-      <th scope="row">ID</th>
-      <td>{{ item.id }}</td>
-    </tr>
-    <tr>
-      <th scope="row">Model</th>
-      <td>{{ item.model }}</td>
-    </tr>
-    <tr>
-      <th scope="row">Brand</th>
-      <td>{{ item.brand }}</td>
-    </tr>
-    <tr>
-      <th scope="row">Quantity</th>
-      <td>{{ item.quantity }}</td>
-    </tr>
-    <tr>
-      <th scope="row">Description</th>
-      <td>{{ item.description }}</td>
-    </tr>
-    <tr>
-      <th scope="row">Location</th>
-      <td>{{ item.location }}</td>
-    </tr>
-    <tr>
-      <th scope="row">Status</th>
-      <td>{{ item.item_status }}</td>
-    </tr>
-    <tr>
-      <th scope="row">Type</th>
-      <td>{{ item.type }}</td>
-    </tr>
-    <tr>
-      <th scope="row">Category</th>
-      <td>{{ item.category }}</td>
-    </tr>
-    <tr>
-      <th scope="row">Order Date</th>
-      <td>{{ item.order_date }}</td>
-    </tr>
-    <tr>
-      <th scope="row">Check Date</th>
-      <td>{{ item.check_date }}</td>
-    </tr>
+            <table class="table">
+          <thead>
+            <tr>
+              <th scope="col" colspan="2">Item: {{ item.model }}</th>
+            </tr>
+          </thead>
+          <tbody>
+            <tr>
+              <th scope="row">ID</th>
+              <td>{{ item.id }}</td>
+            </tr>
+            <tr>
+              <th scope="row">Model</th>
+              <td>{{ item.model }}</td>
+            </tr>
+            <tr>
+              <th scope="row">Brand</th>
+              <td>{{ item.brand }}</td>
+            </tr>
+            <tr>
+              <th scope="row">Quantity</th>
+              <td>{{ item.quantity }}</td>
+            </tr>
+            <tr>
+              <th scope="row">Description</th>
+              <td>{{ item.description }}</td>
+            </tr>
+            <tr>
+              <th scope="row">Location</th>
+              <td>{{ item.location }}</td>
+            </tr>
+            <tr>
+              <th scope="row">Status</th>
+              <td>{{ item.item_status }}</td>
+            </tr>
+            <tr>
+              <th scope="row">Type</th>
+              <td>{{ item.type }}</td>
+            </tr>
+            <tr>
+              <th scope="row">Category</th>
+              <td>{{ item.category }}</td>
+            </tr>
+            <tr>
+              <th scope="row">Order Date</th>
+              <td>{{ item.order_date }}</td>
+            </tr>
+            <tr>
+              <th scope="row">Check Date</th>
+              <td>{{ item.check_date }}</td>
+            </tr>
+        </table>
+        </div>
+        <div class="col-sm">
+            <a class="btn btn-primary" href="{% url 'items' %}" role="button">Volver a Items</a>
+        </div>
+    </div>
 
-  </tbody>
-</table>
 </div>
 {% endblock %}

--- a/inventory/templates/inventory/items.html
+++ b/inventory/templates/inventory/items.html
@@ -25,6 +25,7 @@
                             <th class="centered">Description</th>
                             <th class="centered">Location</th>
                             <th class="centered">Status</th>
+                            <th>-</th>
                         </tr>
                     </thead>
                     <tbody id="tableBody_items"></tbody>

--- a/inventory/urls.py
+++ b/inventory/urls.py
@@ -7,4 +7,5 @@ urlpatterns = [
     path("", views.index, name="index"),
     path("list_items/", views.list_items, name="list_items"),
     path("items/", views.items, name="items"),
+    path("items/<item_id>/", views.item_detail, name="item_details"),
 ]

--- a/inventory/views.py
+++ b/inventory/views.py
@@ -20,3 +20,9 @@ def list_items(request):
 
 def items(request):
     return render(request, "inventory/items.html")
+
+
+def item_detail(request, item_id):
+    item = Item.objects.get(pk=item_id)
+    context = {"item": item}
+    return render(request, "inventory/item_detail.html", context)


### PR DESCRIPTION
This PR adds the item detail view and template. 
Also, hardcoded urls have been fixed for the base template with the {% url %} instead

Screenshots:
Added details link:
<img width="1504" alt="Screen Shot 2023-06-03 at 12 19 49" src="https://github.com/dani-y-jose/simple-inventory/assets/7221505/5184142c-5350-470c-9e7d-c4edfdca744a">

Item details page:
<img width="948" alt="Screen Shot 2023-06-03 at 12 20 31" src="https://github.com/dani-y-jose/simple-inventory/assets/7221505/ffb741c9-1fea-4f11-9274-661ee389e022">
